### PR TITLE
Context API

### DIFF
--- a/src/react.js
+++ b/src/react.js
@@ -4,27 +4,27 @@ function _createProviderComponent (token) {
   return defineComponent({
     props: ['value'],
     setup (props, { slots }) {
-      provide(token, toRef(props, 'value'))
-      return () => slots.default()
+      provide(token, toRef(props, 'value'));
+      return () => slots.default();
     },
-  })
+  });
 }
 
 function _createConsumerComponent (token, defaultValue) {
   return (props, { slots }) => {
-    const injection = unref(inject(token, defaultValue))
-    return slots.default(injection)
-  }
+    const injection = unref(inject(token, defaultValue));
+    return slots.default(injection);
+  };
 }
 
 export function createContext(defaultValue) {
-  const token = Symbol()
+  const token = Symbol();
   return {
     _defaultValue: defaultValue,
     _token: token,
     Provider: _createProviderComponent(token),
     Consumer: _createConsumerComponent(token, defaultValue)
-  }
+  };
 }
 
 export function forwardRef() {
@@ -210,7 +210,7 @@ export function useRef(initialValue) {
 }
 
 export function useContext(context) {
-  return unref(inject(context._token, context._defaultValue))
+  return unref(inject(context._token, context._defaultValue));
 }
 
 export function useCallback(cb, deps) {


### PR DESCRIPTION
This PR includes basic support to React-like Context API, including:

- `createContext`
- `useContext`
- `Context.Provider` & `Context.Consumer`

This PR doesn't include:
- Support for the (undocumented?) second parameter of `createContext`
- Support for `Class.contextType`
- Support for `displayName`<sup>1</sup>

At a quick look at React Aria source, I couldn't locate many references to `Provider` and `Consumer` as components. If you don't consider them useful, I could remove it.

I've implemented those functions using analogous `provide`/`inject` features present in Vue. The implementation supposes that contexts are created and consumed inside Vue.

<sup>1</sup> It could be investigated in future. I don't know if Vue allows component's name as a getter.

---

I couldn't apply the patches and run the demo, so I couldn't test them against the React Aria codebase; therefore, I'm marking the PR as "draft".

For a running demo, see https://codepen.io/leopiccionia/pen/JjXzwON.